### PR TITLE
Add script to run all ax commands that do not seriously impact device.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,3 +2,5 @@
 
 - [ ] I have updated any documentation
 - [ ] I have run `rubocop` and all checks are passing
+- [ ] I have added any new features to `run_tests`
+- [ ] I have run `run_tests` and nothing fails

--- a/run_tests
+++ b/run_tests
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Running all non-mutating (or easily reversible) commands"
+
+ax list_packages
+ax max_bright
+ax permissions com.android.settings
+ax settings_app
+ax reboot


### PR DESCRIPTION
We want a quick and dirty way to see if most scripts are at least not crashing.

## Tasks

- [x] I have updated any documentation
- [x] I have run `rubocop` and all checks are passing