### PR TITLE
Add function to print processor info

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ List entire `dumpsys` for a package, with highlighting for <span style="color:gr
 
 ![](images/permissiondump.png)
 
+##### `$ ax processor`
+
+Print information on device's processor(s)
+
 ##### `$ ax pull_apks PACKAGE LOCATION`
 
 Pull all apks from device to local machine, for a given package. Optionally set location on local machine
@@ -103,11 +107,11 @@ Capture a device screenshot, saving to optional destination, or current director
 
 Launch system Settings app
 
-##### `$ ax uninstall_package PACKAGE_NAME`
+##### `$ ax uninstall_package PACKAGE`
 
 Uninstalls package by name
 
-##### `$ ax version_name PACKAGE_NAME`
+##### `$ ax version_name PACKAGE`
 
 Print package's [version name](https://developer.android.com/guide/topics/manifest/manifest-element#vname)
 

--- a/ax_completion.bash
+++ b/ax_completion.bash
@@ -1,10 +1,10 @@
-_ax_completions() 
+_ax_completions()
 {
     local cur prev opts
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    primary_opts="add_wifi clear_app_data disable_audio display launch_app layout_bounds list_packages help max_bright night_mode permissions pull_apks reboot screenshot, settings_app uninstall_package version_name"
+    primary_opts="add_wifi clear_app_data disable_audio display launch_app layout_bounds list_packages help max_bright night_mode permissions processor pull_apks reboot screenshot, settings_app uninstall_package version_name"
 
     #remember: COMP_WORDS[0] is `ax`
     # tab complete primary word in command string

--- a/commands.rb
+++ b/commands.rb
@@ -12,6 +12,7 @@ require_relative 'list_packages'
 require_relative 'max_bright'
 require_relative 'night_mode'
 require_relative 'permissions'
+require_relative 'processor'
 require_relative 'pull_apks'
 require_relative 'reboot_and_wait'
 require_relative 'screenshot'
@@ -32,6 +33,7 @@ module Commands
     MaxBright,
     NightMode,
     Permissions,
+    Processor,
     PullApks,
     RebootAndWait,
     Screenshot,

--- a/print_manual.rb
+++ b/print_manual.rb
@@ -16,6 +16,7 @@ def print_manual
   puts '   max_bright:      set display to max brightness'
   puts '   night mode [on|off|auto]:      turn device night mode to on, off, or auto'
   puts '   permissions [package]: list permissions for package (highlighted in larger dumpsys)'
+  puts '   processor : print information about deivce processor(s)'
   puts '   pull_apks [destination] : download apks from device to optional destination or current directory'
   puts '   reboot:          reboot the device'
   puts '   screenshot [destination] :   capture screenshot and save to optional destination or current directory'

--- a/processor.rb
+++ b/processor.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative 'packages'
+
+class Processor
+  def self.name
+    'processor'
+  end
+
+  def self.perform(*_args)
+    stdout_str, = Open3.capture2('adb shell cat /proc/cpuinfo')
+    puts stdout_str
+  end
+
+  def self.similar_sounding_commands
+    %w[cpu]
+  end
+end

--- a/run_tests
+++ b/run_tests
@@ -26,4 +26,5 @@ ax night_mode on
 ax night_mode off
 ax night_mode auto
 ax display
+ax processor
 ax reboot


### PR DESCRIPTION
Fixes #42  

After some testing w/ various devices, there isn't any uniform processor information to pull out of these output and put in pretty format. Different manufactures do different things. So just print everything.

## Tasks

- [X] I have updated any documentation
- [X] I have run `rubocop` and all checks are passing
- [X] I have run `run_tests` and nothing fails

## Adding New Function

- [X] I have added to README
- [X] I have added to `commands.rb KNOWN_COMMANDS`
- [X] I have added to `run_tests`
- [X] I have added to `ax_completion.bash`
