### PR TITLE
Add option to set accessibility font scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Disable device's audio, per stream. Supports all `AudioManager.STREAM_*`:
 
 Print device's display size and density
 
+##### `$ ax font_scale small|default|large|largest`
+
+Set accessibility font scale. Mimics small, default, large, largest options as if set from system Setttings app.
+
 ##### `$ ax launch_app PACKAGE`
 
 Launch an app by package name

--- a/ax_completion.bash
+++ b/ax_completion.bash
@@ -4,7 +4,7 @@ _ax_completions()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    primary_opts="add_wifi clear_app_data disable_audio display launch_app layout_bounds list_packages help max_bright night_mode permissions processor pull_apks reboot screenshot settings_app talkback uninstall_package version_name"
+    primary_opts="add_wifi clear_app_data disable_audio display font_scale launch_app layout_bounds list_packages help max_bright night_mode permissions processor pull_apks reboot screenshot settings_app talkback uninstall_package version_name"
 
     #remember: COMP_WORDS[0] is `ax`
     # tab complete primary word in command string
@@ -26,5 +26,12 @@ _ax_completions()
           COMPREPLY=( $(compgen -W "${night_mode_opts}" -- ${cur}) )
           return 0
         fi
+
+    # secondary tab completion for font_scale
+    font_scale_opts="small default large largest"
+      if [[ ${#COMP_WORDS[@]}  == 3  && ${COMP_WORDS[1]}  == "font_scale" ]] ; then
+        COMPREPLY=( $(compgen -W "${font_scale_opts}" -- ${cur}) )
+        return 0
+      fi
 }
 complete -F _ax_completions ax

--- a/commands.rb
+++ b/commands.rb
@@ -4,6 +4,7 @@ require_relative 'add_wifi'
 require_relative 'clear_app_data'
 require_relative 'disable_audio'
 require_relative 'display'
+require_relative 'font_scale'
 require_relative 'help'
 require_relative 'launch_system_settings'
 require_relative 'launch_app'
@@ -26,6 +27,7 @@ module Commands
     ClearAppData,
     DisableAudio,
     Display,
+    FontScale,
     Help,
     LaunchApp,
     LaunchSystemSettings,

--- a/font_scale.rb
+++ b/font_scale.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative 'packages'
+require 'open3'
+
+class FontScale
+  def self.name
+    'font_scale'
+  end
+
+  # https://developer.android.com/reference/android/provider/Settings.System#FONT_SCALE
+  def self.scales
+    {
+      'small' => 0.85,
+      'default' => 1,
+      'large' => 1.15,
+      'largest' => 1.30
+    }
+  end
+
+  def self.perform(*args)
+    scale = args[0]
+    return unless validate_scale_input(scale)
+
+    size_int = scales[scale]
+
+    Open3.capture2("adb shell settings put system font_scale #{size_int}")
+  end
+
+  def self.similar_sounding_commands
+    %w[size typeface font scale accessibility]
+  end
+
+  def self.validate_scale_input(scale)
+    if scale.nil? || !scales.key?(scale)
+      puts "Unknown scale: #{scale}. Choices are: "
+      scales.each_key do |key|
+        puts "  #{key}"
+      end
+      return false
+    end
+    true
+  end
+end

--- a/print_manual.rb
+++ b/print_manual.rb
@@ -9,6 +9,7 @@ def print_manual
   puts '   clear_app_data [package]:   clear app data, including cache and accepted permissions'
   puts '   disable_audio [audio_stream]:   lower a specific audio stream volume to zero'
   puts '   display:   print display size and density'
+  puts '   font_scale [small|default|large|largest]:  sets accessibility font scale'
   puts '   help:            print this help manual'
   puts '   launch_app [package]:  launch a specific application by package name'
   puts '   layout_bounds [show|hide]:   show or hide layout bounds'

--- a/run_tests
+++ b/run_tests
@@ -30,4 +30,9 @@ ax processor
 ax talkback on
 sleep 3
 ax talkback off
+ax font_scale small
+ax font_scale default
+ax font_scale large
+ax font_scale largest
+ax font_scale default
 ax reboot


### PR DESCRIPTION
Fixes #72 

## Tasks

- [x] I have updated any documentation
- [x] I have run `rubocop` and all checks are passing
- [x] I have run `run_tests` and nothing fails

## Adding New Function

- [x] I have added to README
- [x] I have added to `commands.rb KNOWN_COMMANDS`
- [x] I have added to `run_tests`
- [x] I have added to `ax_completion.bash`
