### PR TITLE
Add some commands for shared preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,18 @@ Capture a device screenshot, saving to optional destination, or current director
 
 Launch system Settings app
 
+##### `$ ax shared_prefs list PACKAGE`
+
+List all shared preferences files within a package
+
+##### `$ ax shared_prefs list PACKAGE FILE_NAME`
+
+Print the content of a single shared preferences file within a single package
+
+##### `$ ax shared_prefs remove PACKAGE FILE_NAME PREF_NAME`
+
+Remove a single value from a shared preferences file
+
 ##### `$ ax talkback on|off`
 
 Set Talkback on or off

--- a/ax_completion.bash
+++ b/ax_completion.bash
@@ -4,7 +4,7 @@ _ax_completions()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    primary_opts="add_wifi airplane_mode animation_scale clear_app_data disable_audio display display_scale font_scale launch_app layout_bounds list_packages help max_bright night_mode permissions processor pull_apks reboot screenshot settings_app talkback uninstall_package version_name"
+    primary_opts="add_wifi airplane_mode animation_scale clear_app_data disable_audio display display_scale font_scale launch_app layout_bounds list_packages help max_bright night_mode permissions processor pull_apks reboot screenshot settings_app shared_prefs talkback uninstall_package version_name"
 
     #remember: COMP_WORDS[0] is `ax`
     # tab complete primary word in command string
@@ -45,6 +45,13 @@ _ax_completions()
     display_scale_opts="small default large larger largest"
       if [[ ${#COMP_WORDS[@]}  == 3  && ${COMP_WORDS[1]}  == "display_scale" ]] ; then
         COMPREPLY=( $(compgen -W "${display_scale_opts}" -- ${cur}) )
+        return 0
+      fi
+
+  # secondary tab completion for shared_prefs
+    shared_prefs_opts="list remove"
+      if [[ ${#COMP_WORDS[@]}  == 3  && ${COMP_WORDS[1]}  == "shared_prefs" ]] ; then
+        COMPREPLY=( $(compgen -W "${shared_prefs_opts}" -- ${cur}) )
         return 0
       fi
 }

--- a/commands.rb
+++ b/commands.rb
@@ -20,6 +20,7 @@ require_relative 'processor'
 require_relative 'pull_apks'
 require_relative 'reboot_and_wait'
 require_relative 'screenshot'
+require_relative 'shared_prefs'
 require_relative 'talkback'
 require_relative 'uninstall_package'
 require_relative 'version_name'
@@ -46,6 +47,7 @@ module Commands
     PullApks,
     RebootAndWait,
     Screenshot,
+    SharedPrefs,
     Talkback,
     UninstallPackage,
     VersionName

--- a/shared_prefs.rb
+++ b/shared_prefs.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require_relative 'validate_package'
+
+class SharedPrefs
+  def self.name
+    'shared_prefs'
+  end
+
+  def self.perform(*args)
+    subcommand = args[0]
+    return unless validate_sub_command(subcommand)
+
+    package_name = args[1]
+    return unless validate_package(package_name)
+
+    # don't validate these until we need them; they don't need to be supplied for all subcommands
+    file_name = args[2]
+    pref_name = args[3]
+
+    file_name_present = !file_name.nil? && !file_name.empty?
+
+    case subcommand
+    when "list"
+      if file_name_present
+        puts "Listing shared prefs content for #{package_name} / #{file_name}:\n\n"
+        full_file_path = "/data/data/#{package_name}/shared_prefs/#{file_name}"
+        return unless validate_file_exists(package_name, full_file_path, file_name)
+
+        list_contents_of_single_file = ->(stdin) {
+          stdin.write "run-as #{package_name}\n"
+          stdin.write "cat #{full_file_path}\n"
+        }
+        run_as_adb_shell(list_contents_of_single_file)
+
+      else
+        puts "Listing all shared prefs files for #{package_name}:\n\n"
+        list_all_shared_prefs_files = ->(stdin) {
+          stdin.write "run-as #{package_name}\n"
+          stdin.write "ls -al /data/data/#{package_name}/shared_prefs\n"
+        }
+        run_as_adb_shell(list_all_shared_prefs_files)
+      end
+
+    when "remove"
+      return unless validate_file_exists(package_name, full_file_path, file_name)
+      return unless validate_pref_name(pref_name)
+
+      puts "Removing #{pref_name} from shared prefs #{package_name} / #{file_name}"
+      clear_single_shared_pref = ->(stdin) {
+        stdin.write "run-as #{package_name}\n"
+        full_file_name = "/data/data/#{package_name}/shared_prefs/#{file_name}"
+        regex = "'/^.*name=\"#{pref_name}\".*$/d'"
+        stdin.write "sed -i #{regex} #{full_file_name}\n"
+      }
+      run_as_adb_shell(clear_single_shared_pref)
+      puts "You may need to restart application for changes to take effect."
+    end
+  end
+
+  def self.validate_pref_name(pref_name)
+    if pref_name.nil? || pref_name.empty?
+      puts 'Failed to supply preference name'
+      return false
+    end
+    return true
+    # TODO validate that pref is even there before we try to clear it
+    # TODO if we don't find it try to scan all of the other pref files in this package
+  end
+
+  def self.validate_file_exists(package_name, full_file_path, file_name)
+    Open3.pipeline_rw "adb shell" do |stdin, stdout, _ts|
+      stdin.write "run-as #{package_name}\n"
+      stdin.write "if [ -e #{full_file_path} ]; then echo true; else echo false; fi \n"
+      stdin.close
+      out = stdout.read # adb will return true/false as a string with a carriage returnru
+      if out.strip() == "false"
+        puts "Invalid file name: #{file_name}"
+        return false
+      else
+        return true
+      end
+    end
+    Process.waitall
+  end
+
+  def self.run_as_adb_shell(lambda)
+    Open3.pipeline_rw "adb shell" do |stdin, stdout, _ts|
+      # I can write to adb shell all day long
+      lambda.call(stdin)
+      stdin.write "exit\n"
+      stdin.close
+      out = stdout.read
+      puts out
+    end
+    Process.waitall
+  end
+
+  def self.validate_sub_command(subcommand)
+    valid_subcommands = ["list", "remove"]
+    unless valid_subcommands.include? subcommand
+      puts "Unknown subcommand: #{subcommand}. Choices are: "
+      valid_subcommands.each { |x|
+        puts "  #{x}"
+      }
+      return false
+    end
+    true
+  end
+
+  def self.similar_sounding_commands;
+    %w[preferences share shared list remove delete]
+  end
+end


### PR DESCRIPTION
This is a good start on #98 


* list all files
* list contents of individual files
* remove a single shared prefs

## Tasks

- [x] I have updated any documentation
- [x] I have run `rubocop` and all checks are passing
- [x] I have run `run_tests` and nothing fails

## Adding New Function

- [x] I have added to README
- [x] I have added to `commands.rb KNOWN_COMMANDS`
- NOPE, no way to test unless I put a debug app on my emulator;  I have added to `run_tests`
- [x] I have added to `ax_completion.bash`
